### PR TITLE
consensus: rename consensus bsrr to amon with api methods

### DIFF
--- a/berith/backend.go
+++ b/berith/backend.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/BerithFoundation/berith-chain/berith/staking"
 
-	"github.com/BerithFoundation/berith-chain/consensus/bsrr"
+	"github.com/BerithFoundation/berith-chain/consensus/amon"
 
 	"github.com/BerithFoundation/berith-chain/accounts"
 	"github.com/BerithFoundation/berith-chain/berith/brtapi"
@@ -240,7 +240,7 @@ func CreateDB(ctx *node.ServiceContext, config *Config, name string) (berithdb.D
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Berith service
 func CreateConsensusEngine(chainConfig *params.ChainConfig, db berithdb.Database, stakingDB *stakingdb.StakingDB) consensus.Engine {
-	return bsrr.NewCliqueWithStakingDB(stakingDB, chainConfig.Bsrr, db)
+	return amon.NewAmonWithStakingDB(stakingDB, chainConfig.Amon, db)
 }
 
 // APIs return the collection of RPC services the berith package offers.
@@ -405,13 +405,13 @@ func (s *Berith) StartMining(threads int) error {
 			log.Error("Cannot start mining without berithbase", "err", err)
 			return fmt.Errorf("berithbase missing: %v", err)
 		}
-		if bsrr, ok := s.engine.(*bsrr.BSRR); ok {
+		if amon, ok := s.engine.(*amon.Amon); ok {
 			wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
 			if wallet == nil || err != nil {
 				log.Error("Berithbase account unavailable locally", "err", err)
 				return fmt.Errorf("signer missing: %v", err)
 			}
-			bsrr.Authorize(eb, wallet.SignHash)
+			amon.Authorize(eb, wallet.SignHash)
 		}
 		// If mining is started, we can disable the transaction rejection mechanism
 		// introduced to speed sync times.

--- a/berith/brtapi/api.go
+++ b/berith/brtapi/api.go
@@ -182,8 +182,8 @@ func (s *PrivateBerithAPI) Stake(ctx context.Context, args WalletTxArgs) (common
 	totalStakingAmount := new(big.Int).Add(stakingAmount,stakedAmount)
 
 	if config := s.backend.ChainConfig(); config.IsEIP155(s.backend.CurrentBlock().Number()) {
-		if totalStakingAmount.Cmp(config.Bsrr.StakeMinimum) <= -1 {
-			minimum := new(big.Int).Div(config.Bsrr.StakeMinimum, big.NewInt(1e+18))
+		if totalStakingAmount.Cmp(config.Amon.StakeMinimum) <= -1 {
+			minimum := new(big.Int).Div(config.Amon.StakeMinimum, big.NewInt(1e+18))
 
 			log.Error("The minimum number of stakes is " + strconv.Itoa(int(minimum.Uint64())))
 			return common.Hash{}, errors.New("staking balance failed")

--- a/cmd/gwizard/wizard_genesis.go
+++ b/cmd/gwizard/wizard_genesis.go
@@ -51,9 +51,9 @@ func (w *wizard) makeGenesis() {
 		},
 	}
 
-	// In the case of bsrr, configure the consensus parameters
+	// In the case of amon, configure the consensus parameters
 	genesis.Difficulty = big.NewInt(1)
-	genesis.Config.Bsrr = &params.BSRRConfig{
+	genesis.Config.Amon = &params.AmonConfig{
 		Period:       30,
 		Epoch:        300,
 		Rewards:      big.NewInt(500),
@@ -68,7 +68,7 @@ func (w *wizard) makeGenesis() {
 
 	fmt.Println()
 	fmt.Println("How many seconds should blocks take? (default = 15)")
-	genesis.Config.Bsrr.Period = uint64(w.readDefaultInt(15))
+	genesis.Config.Amon.Period = uint64(w.readDefaultInt(15))
 
 	// We also need the initial signer during epoch i.e from 0 to epoch
 	fmt.Println()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BerithFoundation/berith-chain/consensus/bsrr"
+	"github.com/BerithFoundation/berith-chain/consensus/amon"
 
 	"github.com/BerithFoundation/berith-chain/accounts"
 	"github.com/BerithFoundation/berith-chain/accounts/keystore"
@@ -1313,7 +1313,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 		Fatalf("%v", err)
 	}
 	var engine consensus.Engine
-	engine = bsrr.New(config.Bsrr, chainDb)
+	engine = amon.New(config.Amon, chainDb)
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
 	}

--- a/consensus/amon/amon_test.go
+++ b/consensus/amon/amon_test.go
@@ -1,4 +1,4 @@
-package bsrr
+package amon
 
 import (
 	"testing"
@@ -10,8 +10,8 @@ import (
 )
 
 func TestGetMaxMiningCandidates(t *testing.T) {
-	var c = &BSRR{
-		config: &params.BSRRConfig{
+	var c = &Amon{
+		config: &params.AmonConfig{
 			Period:       10,
 			Epoch:        360,
 			Rewards:      common.StringToBig("20000"),
@@ -41,8 +41,8 @@ func TestGetMaxMiningCandidates(t *testing.T) {
 }
 
 func TestGetDelay(t *testing.T) {
-	var c = &BSRR{
-		config: &params.BSRRConfig{
+	var c = &Amon{
+		config: &params.AmonConfig{
 			Period:       0,
 			Epoch:        360,
 			Rewards:      common.StringToBig("20000"),

--- a/consensus/amon/snapshot.go
+++ b/consensus/amon/snapshot.go
@@ -9,24 +9,24 @@ Y8888P' Y88888P 88   YD Y888888P    YP    YP   YP
 	  copyrights by ibizsoftware 2018 - 2019
 */
 
-package bsrr
+package amon
 
 import (
 	"bytes"
 	"encoding/json"
 
 	"github.com/BerithFoundation/berith-chain/berith/staking"
+	"github.com/BerithFoundation/berith-chain/berithdb"
 	"github.com/BerithFoundation/berith-chain/common"
 	"github.com/BerithFoundation/berith-chain/consensus"
 	"github.com/BerithFoundation/berith-chain/core/types"
-	"github.com/BerithFoundation/berith-chain/berithdb"
 	"github.com/BerithFoundation/berith-chain/params"
 	lru "github.com/hashicorp/golang-lru"
 )
 
 // Snapshot is the state of the authorization voting at a given point in time.
 type Snapshot struct {
-	config   *params.BSRRConfig // Consensus engine parameters to fine tune behavior
+	config   *params.AmonConfig // Consensus engine parameters to fine tune behavior
 	sigcache *lru.ARCCache      // Cache of recent block signatures to speed up ecrecover
 
 	Number  uint64                      `json:"number"`  // Block number where the snapshot was created
@@ -44,7 +44,7 @@ func (s signersAscending) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // newSnapshot creates a new snapshot with the specified startup parameters. This
 // method does not initialize the set of recent signers, so only ever use if for
 // the genesis block.
-func newSnapshot(config *params.BSRRConfig, sigcache *lru.ARCCache, number uint64, hash common.Hash, signers []common.Address) *Snapshot {
+func newSnapshot(config *params.AmonConfig, sigcache *lru.ARCCache, number uint64, hash common.Hash, signers []common.Address) *Snapshot {
 	snap := &Snapshot{
 		config:   config,
 		sigcache: sigcache,
@@ -59,8 +59,8 @@ func newSnapshot(config *params.BSRRConfig, sigcache *lru.ARCCache, number uint6
 }
 
 // loadSnapshot loads an existing snapshot from the database.
-func loadSnapshot(config *params.BSRRConfig, sigcache *lru.ARCCache, db berithdb.Database, hash common.Hash) (*Snapshot, error) {
-	blob, err := db.Get(append([]byte("bsrr-"), hash[:]...))
+func loadSnapshot(config *params.AmonConfig, sigcache *lru.ARCCache, db berithdb.Database, hash common.Hash) (*Snapshot, error) {
+	blob, err := db.Get(append([]byte("amon-"), hash[:]...))
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (s *Snapshot) store(db berithdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append([]byte("bsrr-"), s.Hash[:]...), blob)
+	return db.Put(append([]byte("amon-"), s.Hash[:]...), blob)
 }
 
 // copy creates a deep copy of the snapshot, though not the individual votes.
@@ -108,7 +108,7 @@ func (s *Snapshot) validVote(address common.Address, authorize bool) bool {
 
 // apply creates a new authorization snapshot by applying the given headers to
 // the original one.
-func (s *Snapshot) apply(chain consensus.ChainReader, stakingDB staking.DataBase, headers []*types.Header, c *BSRR) (*Snapshot, error) {
+func (s *Snapshot) apply(chain consensus.ChainReader, stakingDB staking.DataBase, headers []*types.Header, c *Amon) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -631,7 +631,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	*/
 	stakedAmount := pool.currentState.GetStakeBalance(from)
 	totalStakingAmount := tx.Value().Add(tx.Value(), stakedAmount)
-	minimum := pool.chainconfig.Bsrr.StakeMinimum
+	minimum := pool.chainconfig.Amon.StakeMinimum
 	if tx.Base() == types.Main && tx.Target() == types.Stake {
 		if totalStakingAmount.Cmp(minimum) == -1 {
 			return ErrStakingBalance

--- a/doc/README_KOR.md
+++ b/doc/README_KOR.md
@@ -87,7 +87,7 @@ Service miner
 | `stop` | 마이닝을 정지 합니다.  |
 | `setBerithbase` | 계정을 선택합니다.  |
 
-Service bsrr
+Service amon
 
 |  Command    | Description |
 |:----------:|-------------|

--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -13,9 +13,11 @@
 
 - <a href="#web3_clientVersion">web3_clientVersion</a>  
 - <a href="#web3_sha3">web3_sha3</a>  
+
 - <a href="#net_version">net_version</a>
 - <a href="#net_peerCount">net_peerCount</a>  
 - <a href="#net_listening">net_listening</a>  
+
 - <a href="#berith_protocolVersion">berith_protocolVersion</a>  
 - <a href="#berith_coinbase">berith_coinbase</a>  
 - <a href="#berith_syncing">berith_syncing</a>
@@ -49,6 +51,10 @@
 - <a href="#berith_getFilterChanges">berith_getFilterChanges</a>  
 - <a href="#berith_getFilterLogs">berith_getFilterLogs</a>  
 - <a href="#berith_getLogs">berith_getLogs</a>  
+
+- <a href="#amon_getBlockCreatorsByNumber">amon_getBlockCreatorsByNumber</a>
+- <a href="#amon_getBlockCreatorsByHash">amon_getBlockCreatorsByHash</a>
+- <a href="#amon_getJoinRatio">amon_getJoinRatio</a>
   
 ---  
 
@@ -1382,3 +1388,85 @@ curl --data '{"jsonrpc":"2.0","method":"berith_getLogs","params":[{"topics":["0x
 ```
 
 ---  
+
+<div id="amon_getBlockCreatorsByNumber"></div>  
+
+### amon_getBlockCreatorsByNumber  
+Returns an array of addresses who can seal a block the given block number.
+
+**Parameter**
+1. `QUANTITY|TAG`, 32 Bytes - Hash of a block.  
+
+
+**Returns**  
+`Array of DATA`, 20 Bytes - addresses who can seal a block. 
+
+
+**Example**  
+```js
+// Request
+curl --data '{"jsonrpc":"2.0","method":"amon_getBlockCreatorsByNumber","params":["0x9"],"id":1}' -H "Content-Type: application/json" -X POST localhost:8545
+
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    "Bxca7207de79e55c1a69dbc67a4a2e81dfc62c6ac4",
+    "Bxd8a25ff31c6174ce7bce74ca4a91c2e816dbf91e",
+    "Bx90865e6e6737fe766dd08f39cc2cf1550b5f3875",
+    "Bxbb926bbb0b15ca54d4a19dcdf44fc8940e3f6da3",
+    "Bx8676fb254279ef78c53b8a781e228ab439065786"
+  ]
+}
+```
+
+---  
+
+<div id="amon_getBlockCreatorsByHash"></div>  
+
+### amon_getBlockCreatorsByHash  
+Returns an array of addresses who can seal a block the given block hash.
+
+**Parameter**  
+1. `DATA`, 32 Bytes - Hash of a block.
+
+
+**Returns**    
+See [amon_getBlockCreatorsByNumber](#amon_getBlockCreatorsByNumber)
+
+
+**Example**  
+```js
+// Request
+curl --data '{"jsonrpc":"2.0","method":"amon_getBlockCreatorsByHash","params":["0x398514d5a403e6245f1af54f96d262f21a8a9bef1fb9b7920e46f14047752cb7"],"id":1}' -H "Content-Type: application/json" -X POST localhost:8545
+```
+
+---  
+
+<div id="amon_getJoinRatio"></div>  
+
+### amon_getJoinRatio  
+Returns a probability of the top of block creators. probability is determined by stake amount.
+
+**Parameter**  
+1. `DATA`, 20 Bytes - address to check probability of the top of block creators
+2. `QUANTITY|TAG`, 32 Bytes - Hash of a block.
+
+
+**Returns**    
+Returns a probability `float64`
+
+
+**Example**  
+```js
+// Request
+curl --data '{"jsonrpc":"2.0","method":"amon_getJoinRatio","params":["Bxbb926bbb0b15ca54d4a19dcdf44fc8940e3f6da3", "0x14"],"id":1}' -H "Content-Type: application/json" -X POST localhost:8545
+
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": 0.13333333333333333
+}
+```

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -30,7 +30,7 @@ var Modules = map[string]string{
 	"admin":      Admin_JS,
 	"chequebook": Chequebook_JS,
 	"clique":     Clique_JS,
-	"bsrr":       Bsrr_JS,
+	"amon":       Amon_JS,
 	"debug":      Debug_JS,
 	"berith":     BERITH_JS,
 	"miner":      Miner_JS,
@@ -119,24 +119,24 @@ web3._extend({
 });
 `
 
-const Bsrr_JS = `
+const Amon_JS = `
  web3._extend({
- 	property: 'bsrr',
+ 	property: 'amon',
  	methods: [
  		new web3._extend.Method({
- 			name: 'getBlockCreators',
- 			call: 'bsrr_getBlockCreators',
+ 			name: 'getBlockCreatorsByNumber',
+ 			call: 'amon_getBlockCreatorsByNumber',
  			params: 1,
  			inputFormatter: [null]
  		}),
  		new web3._extend.Method({
- 			name: 'getSignersAtHash',
- 			call: 'bsrr_getSignersAtHash',
+ 			name: 'getBlockCreatorsByHash',
+ 			call: 'amon_getBlockCreatorsByHash',
  			params: 1
  		}),
  		new web3._extend.Method({
  			name: 'getJoinRatio',
- 			call: 'bsrr_getJoinRatio',
+ 			call: 'amon_getJoinRatio',
  			params: 1,
  			inputFormatter: [web3._extend.formatters.inputAddressFormatter]
  		}),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -959,7 +959,8 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 			feesBer := new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ber)))
 
 			log.Info("Commit new mining work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
-				"uncles", len(uncles), "txs", w.current.tcount, "gas", block.GasUsed(), "fees", feesBer, "elapsed", common.PrettyDuration(time.Since(start)))
+				"nonce", block.Nonce(), "uncles", len(uncles), "txs", w.current.tcount, "gas", block.GasUsed(),
+				"fees", feesBer, "elapsed", common.PrettyDuration(time.Since(start)))
 
 		case <-w.exitCh:
 			log.Info("Worker has exited")

--- a/params/config.go
+++ b/params/config.go
@@ -37,7 +37,7 @@ var (
 		HomesteadBlock: big.NewInt(0),
 		EIP155Block:    big.NewInt(0),
 		EIP158Block:    big.NewInt(0),
-		Bsrr: &BSRRConfig{
+		Amon: &AmonConfig{
 			Period:       10,
 			Epoch:        360,
 			Rewards:      common.StringToBig("20000"),
@@ -62,7 +62,7 @@ var (
 		HomesteadBlock: big.NewInt(0),
 		EIP155Block:    big.NewInt(0),
 		EIP158Block:    big.NewInt(0),
-		Bsrr: &BSRRConfig{
+		Amon: &AmonConfig{
 			Period:       5,
 			Epoch:        40,
 			Rewards:      common.StringToBig("20000"),
@@ -119,9 +119,9 @@ type ChainConfig struct {
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
-	Bsrr *BSRRConfig `json:"bsrr,omitempty"`
+	Amon *AmonConfig `json:"amon,omitempty"`
 }
-type BSRRConfig struct {
+type AmonConfig struct {
 	Period       uint64   `json:"period"`       // Number of seconds between blocks to enforce
 	Epoch        uint64   `json:"epoch"`        // Epoch length to determine stakeholder
 	Rewards      *big.Int `json:"rewards"`      // Start block number of mining reward
@@ -130,16 +130,16 @@ type BSRRConfig struct {
 	ForkFactor   float64  `json:"forkfactor"`   // Number of mining candidates given stake holders
 }
 
-func (b *BSRRConfig) String() string {
-	return "bsrr"
+func (b *AmonConfig) String() string {
+	return "amon"
 }
 
 // String implements the fmt.Stringer interface.
 func (c *ChainConfig) String() string {
 	var engine interface{}
 	switch {
-	case c.Bsrr != nil:
-		engine = c.Bsrr
+	case c.Amon != nil:
+		engine = c.Amon
 	default:
 		engine = "unknown"
 	}


### PR DESCRIPTION
- rename consensus "bsrr" to "amon"
- refactor to amon's api methods
- adds amon's rpc methods documents